### PR TITLE
 Kontrola definice řídících struktur

### DIFF
--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -32,6 +32,7 @@
 
 	<!-- WhiteSpace -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
 
 </ruleset>
 


### PR DESCRIPTION
Kontroluje bílé znaky kolem řídících struktur.

Například: `if($expression) {` -> `if ($expression) {`