### PR TITLE
Mezery za přetypováním a u typehintů metod

### DIFF
--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -33,6 +33,8 @@
 	<!-- WhiteSpace -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+	<rule ref="../../../../slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/ParameterTypeHintSpacingSniff.php"/>
 
 </ruleset>
 


### PR DESCRIPTION
- `(int)$value` -> `(int) $value`
``` php 
function get(\Throwable         $exception) {}
```
->
```php
function get(\Throwable $exception) {}
```