### PR TITLE
Prázdný řádek před returnem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,10 @@
     "name": "pd/coding-standard",
     "description": "Coding standard pro PeckaDesign",
     "require": {
-        "squizlabs/php_codesniffer": "3.2.*",
         "php": "7.*",
-        "slevomat/coding-standard": "4.5.*"
+        "squizlabs/php_codesniffer": "3.2.*",
+        "slevomat/coding-standard": "4.5.*",
+        "escapestudios/symfony2-coding-standard": "3.*"
     },
     "license": "MIT",
     "authors": [

--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <ruleset name="PeckaDesign">
 
-	<config name="installed_paths" value="../../slevomat/coding-standard"/>
-	
+	<config name="installed_paths" value="../../slevomat/coding-standard,../../escapestudios/symfony2-coding-standard"/>
+
 	<!-- Arrays -->
 	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 
@@ -14,13 +14,13 @@
 
 	<!-- Exceptions -->
 	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
-	
+
 	<!-- Files -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
-	<rule ref="Generic.Files.LineEndings"/>	
+	<rule ref="Generic.Files.LineEndings"/>
 	<rule ref="PSR2.Files.EndFileNewline"/>
 	<rule ref="Zend.Files.ClosingTag"/>
-	
+
 	<!-- Functions -->
 	<rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
 
@@ -44,6 +44,9 @@
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Generic.PHP.UpperCaseConstant"/>
+
+	<!-- NewLines -->
+	<rule ref="Symfony.Formatting.BlankLineBeforeReturn"/>
 
 	<!-- WhiteSpace -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>


### PR DESCRIPTION
http://symfony.com/doc/current/contributing/code/standards.html#structure

- Add a blank line before return statements, unless the return is alone inside a statement-group (like an if statement)