### PR TITLE
SlevomatCodingStandard.Functions.StaticClosure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "7.*",
         "squizlabs/php_codesniffer": "3.2.*",
-        "slevomat/coding-standard": "4.5.*",
+        "slevomat/coding-standard": "4.7.*",
         "escapestudios/symfony2-coding-standard": "3.*"
     },
     "license": "MIT",

--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -23,6 +23,7 @@
 
 	<!-- Functions -->
 	<rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
 
 	<!-- Namespaces -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">


### PR DESCRIPTION
- bump slevomat/coding-standard na 4.7
- přidán sniff na použití static closures v případě, že closure nepoužívá ve svém těle `$this`