### PR TITLE
Sniff pro kontrolu formátování zápisu namespacu třídy.

### DIFF
--- a/src/PeckaCodingStandardStrict/ruleset.xml
+++ b/src/PeckaCodingStandardStrict/ruleset.xml
@@ -15,6 +15,12 @@
 	<rule ref="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">
+		<properties>
+			<property name="linesCountBeforeNamespace" value="1" />
+			<property name="linesCountAfterNamespace" value="1" />
+		</properties>
+	</rule>
 
 	<!-- Whitespaces -->
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing" />


### PR DESCRIPTION
V [coding standardu](https://github.com/peckadesign/pecka/wiki/Coding-standard#namespaces) máme uvedeno:

> na začátku souboru je prázdný řádek, definice namespace, dva prázdné řádky

V naší kódové bázi si to ale používáme vesele buď jeden nebo dva řádky, když na to někdo upozorní v review, vede to ke zbytečným diskuzím, takže na to nasadíme robota. Ovšem otázka do pranice: **jeden nebo dva řádky za namespace** ?

cc @peckadesign/programatori 