### PR TITLE
Argument s výchozí hodnotou NULL musí být nullable

### DIFF
--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -53,6 +53,9 @@
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 	<rule ref="Squiz.ControlStructures.ControlSignature"/>
 	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+
+	<!-- TypeHints -->
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 
 </ruleset>


### PR DESCRIPTION
Občas mi stane, že zapomenu argument s výchozí hodnotou `NULL` označit jako nullable, což by vždy měl být.

Na projektu je sniff nasazený v tomto PR https://github.com/peckadesign/megapixel2012/pull/7191 Je u něj k dispozici automatická oprava.