### PR TITLE
Fix property ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach

### DIFF
--- a/src/PeckaCodingStandard/ruleset.xml
+++ b/src/PeckaCodingStandard/ruleset.xml
@@ -87,7 +87,7 @@
 	<!-- Variables -->
 	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
 		<properties>
-			<property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="1" />
+			<property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
 		</properties>
 	</rule>
 </ruleset>

--- a/tests/Success/Variables/UnusedVariable.php
+++ b/tests/Success/Variables/UnusedVariable.php
@@ -5,5 +5,5 @@ $hello = 'Ahoj';
 echo $hello;
 
 foreach ([] as $k => $v) {
-	echo $v;
+	echo $k;
 }


### PR DESCRIPTION
- v releasu v7.0.19 slevomat/coding-standard došlo ke změně používání property ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach, která nyní musí být boolean (viz: https://github.com/slevomat/coding-standard/commit/78d5c137dcf378e178b739462313b88f4f054a7d#diff-cab409323a53ecb0e91f7121aed69b589d5a85274a4a7541033cc235db9ca2c2)
- před touto úpravou se vyhazovala chyba "Fatal error: Uncaught TypeError: SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff::isValueInForeachAndErrorIsIgnored(): Return value must be of type bool, string returned in .../vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Variables/UnusedVariableSniff.php:528"