### PR TITLE
Vypnutí pravidla SpaceBeforeNotSniff

### DIFF
--- a/src/PeckaCodingStandardPSR12Based/ruleset.xml
+++ b/src/PeckaCodingStandardPSR12Based/ruleset.xml
@@ -152,7 +152,6 @@
     <!-- Formatting -->
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="../Sniffs/Formatting/SpaceBeforeNotSniff.php"/>
 
     <!-- Variables -->
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">


### PR DESCRIPTION
Důvod vypnutí:

S novým CS se objevil v určitých případech problém, kdy spolu kolidují 2 pravidla a tím pádem nefunguje cs-fix. Jedná se o případy typu:

```
		$builder->addDefinition($this->prefix('proactiveConfigurationsMapProvider'))
			->setFactory(ProactiveConfigurationsMapProvider::class)
			->setAutowired(! $lazyConfigurationsMap)
		;
```

kdy problém je ten řádek `->setAutowired(! $lazyConfigurationsMap)`. Problém je v tom, že naše pravidlo `/Sniffs/Formatting/SpaceBeforeNotSniff.php` , které psali před nedávnem kluci ze SuperZOO, vyžaduje mezeru před `!`. Po opravě by tedy vzniklo `->setAutowired( ! $lazyConfigurationsMap)` , což je ale problém pro pravidlo `PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket` , které vyžaduje 0 mezer po otevírací závorce volání funkce.